### PR TITLE
Make library work on stable release channel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "morton"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Reinier Maas <reiniermaas@hotmail.com>"]
+edition = "2018"
 
-# METADATA
-description = "morton iterator for rust"
-documentation = "https://github.com/ReinierMaas/morton/"
+description = "Morton space filling curve functions"
+documentation = "https://docs.rs/morton/"
 homepage = "https://github.com/ReinierMaas/morton/"
 repository = "https://github.com/ReinierMaas/morton/"
 readme = "README.md"
@@ -13,41 +13,16 @@ keywords = ["morton", "iterator", "cache-coherence", "spatial-locality", "data-l
 categories = ["algorithms", "caching", "data-structures", "game-engines", "memory-management"]
 license = "MIT"
 
-# Optional specification of badges to be displayed on crates.io. The badges
-# currently available are Travis CI and Appveyor latest build status, specified
-# using the following parameters:
-# [badges]
-# Travis CI: `repository` is required. `branch` is optional; default is `master`
-# travis-ci = { repository = "...", branch = "master" }
-# Appveyor: `repository` is required. `branch` is optional; default is `master`
-# `service` is optional; valid values are `github` (default), `bitbucket`, and
-# `gitlab`.
-# appveyor = { repository = "...", branch = "master", service = "github" }
-
-# PROFILES
-# The development profile, used for `cargo build | run`.
-[profile.dev]
-opt-level = 0
-debug = true
-debug-assertions = true
-
-# The release profile, used for `cargo build | run --release`.
-[profile.release]
-opt-level = 3
-lto = true
-
-# The testing profile, used for `cargo test`.
-[profile.test]
-opt-level = 0
-debug = true
-debug-assertions = true
-
-# The benchmarking profile, used for `cargo bench`.
-[profile.bench]
-opt-level = 3
-lto = true
-
-[dependencies]
+[[bench]]
+harness = false
+name = "morton"
 
 [dev-dependencies]
-rand = "0.3.15"
+bencher = "0.1"
+rand = "0.7"
+
+[profile.release]
+lto = true
+
+[profile.bench]
+lto = true

--- a/benches/morton.rs
+++ b/benches/morton.rs
@@ -1,0 +1,168 @@
+#[macro_use]
+extern crate bencher;
+
+use bencher::{black_box, Bencher};
+use rand::{thread_rng, Rng};
+
+use morton::utils::{idx_tile, idx_tile_tuple};
+use morton::{deinterleave_morton, interleave_morton};
+
+fn interleave_1000(b: &mut Bencher) {
+    let x = thread_rng().gen::<u16>();
+    let y = thread_rng().gen::<u16>();
+    b.iter(|| {
+        for _ in 0..1000 {
+            black_box(interleave_morton(x, y));
+        }
+    });
+}
+
+fn deinterleave_1000(b: &mut Bencher) {
+    let morton = thread_rng().gen::<u32>();
+    b.iter(|| {
+        for _ in 0..1000 {
+            black_box(deinterleave_morton(morton));
+        }
+    });
+}
+
+fn interleave_deinterleave_1000(b: &mut Bencher) {
+    let x = thread_rng().gen::<u16>();
+    let y = thread_rng().gen::<u16>();
+    b.iter(|| {
+        for _ in 0..1000 {
+            black_box(deinterleave_morton(interleave_morton(x, y)));
+        }
+    });
+}
+
+fn deinterleave_interleave_1000(b: &mut Bencher) {
+    let morton = thread_rng().gen::<u32>();
+    b.iter(|| {
+        for _ in 0..1000 {
+            let (x, y) = deinterleave_morton(morton);
+            black_box(interleave_morton(x, y));
+        }
+    });
+}
+
+fn horizontal_access_normal(b: &mut Bencher) {
+    let mut tile_normal = vec![0; 2048 * 2048]; // 16MB allocate more then largest cache
+                                                // fill tiles with some random numbers
+    for y in 0..2048 {
+        for x in 0..2048 {
+            let random = thread_rng().gen::<u32>();
+            tile_normal[idx_tile(x, y, 2048)] = random;
+        }
+    }
+    // bench horizontal access (x direction)
+    b.iter(|| {
+        for y in 0..2048 {
+            for x in 0..2048 {
+                black_box(tile_normal[idx_tile(x, y, 2048)]);
+            }
+        }
+    });
+}
+
+fn vertical_access_normal(b: &mut Bencher) {
+    let mut tile_normal = vec![0; 2048 * 2048]; // 16MB allocate more then largest cache
+                                                // fill tiles with some random numbers
+    for x in 0..2048 {
+        for y in 0..2048 {
+            let random = thread_rng().gen::<u32>();
+            tile_normal[idx_tile(x, y, 2048)] = random;
+        }
+    }
+    // bench vertical access (y direction)
+    b.iter(|| {
+        for x in 0..2048 {
+            for y in 0..2048 {
+                black_box(tile_normal[idx_tile(x, y, 2048) as usize]);
+            }
+        }
+    });
+}
+
+fn morton_access_normal(b: &mut Bencher) {
+    let mut tile_morton = vec![0; 2048 * 2048]; // 16MB allocate more then largest cache
+                                                // fill tiles with some random numbers
+    for z in 0..2048 * 2048 {
+        let random = thread_rng().gen::<u32>();
+        tile_morton[idx_tile_tuple(deinterleave_morton(z), 2048) as usize] = random;
+    }
+    // bench horizontal access (x direction)
+    b.iter(|| {
+        for z in 0..2048 * 2048 {
+            black_box(tile_morton[idx_tile_tuple(deinterleave_morton(z), 2048) as usize]);
+        }
+    });
+}
+
+fn horizontal_access_morton(b: &mut Bencher) {
+    let mut tile_morton = vec![0; 2048 * 2048]; // 16MB allocate more then largest cache
+                                                // fill tiles with some random numbers
+    for y in 0..2048 {
+        for x in 0..2048 {
+            let random = thread_rng().gen::<u32>();
+            tile_morton[interleave_morton(x, y) as usize] = random;
+        }
+    }
+    // bench horizontal access (x direction)
+    b.iter(|| {
+        for y in 0..2048 {
+            for x in 0..2048 {
+                black_box(tile_morton[interleave_morton(x, y) as usize]);
+            }
+        }
+    });
+}
+
+fn vertical_access_morton(b: &mut Bencher) {
+    let mut tile_morton = vec![0; 2048 * 2048]; // 16MB allocate more then largest cache
+                                                // fill tiles with some random numbers
+    for x in 0..2048 {
+        for y in 0..2048 {
+            let random = thread_rng().gen::<u32>();
+            tile_morton[interleave_morton(x, y) as usize] = random;
+        }
+    }
+    // bench vertical access (y direction)
+    b.iter(|| {
+        for x in 0..2048 {
+            for y in 0..2048 {
+                black_box(tile_morton[interleave_morton(x, y) as usize]);
+            }
+        }
+    });
+}
+
+fn morton_access_morton(b: &mut Bencher) {
+    let mut tile_morton = vec![0; 2048 * 2048]; // 16MB allocate more then largest cache
+                                                // fill tiles with some random numbers
+    for z in 0..2048 * 2048 {
+        let random = thread_rng().gen::<u32>();
+        tile_morton[z] = random;
+    }
+    // bench horizontal access (x direction)
+    b.iter(|| {
+        for z in 0..2048 * 2048 {
+            black_box(tile_morton[z]);
+        }
+    });
+}
+
+benchmark_group!(
+    benches,
+    interleave_1000,
+    deinterleave_1000,
+    interleave_deinterleave_1000,
+    deinterleave_interleave_1000,
+    horizontal_access_normal,
+    vertical_access_normal,
+    morton_access_normal,
+    horizontal_access_morton,
+    vertical_access_morton,
+    morton_access_morton
+);
+benchmark_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,7 @@
-#![allow(unused_features)]
-#![feature(test)]
-#[cfg(test)] extern crate rand;
-#[cfg(test)] extern crate test;
-
-// http://graphics.stanford.edu/~seander/bithacks.html#InterleaveBMN
+/// Convert 2D spatial coordinates to Morton z-order value
+///
+/// Uses bithacks as described in:
+/// http://graphics.stanford.edu/~seander/bithacks.html#InterleaveBMN
 #[inline]
 pub fn interleave_morton(x: u16, y: u16) -> u32 {
     if cfg!(target_pointer_width = "64") {
@@ -31,15 +29,17 @@ pub fn interleave_morton(x: u16, y: u16) -> u32 {
         let y = (y | (y << 2)) & 0x33333333;
         let y = (y | (y << 1)) & 0x55555555;
 
-        let z = x | (y << 1);
-        z
+        x | (y << 1)
     }
 }
 
-// http://stackoverflow.com/questions/4909263/how-to-efficiently-de-interleave-bits-inverse-morton
+/// Convert Morton z-order value to 2D spatial coordinates
+///
+/// Uses bithacks as described in:
+/// http://stackoverflow.com/questions/4909263/how-to-efficiently-de-interleave-bits-inverse-morton
 #[inline]
 pub fn deinterleave_morton(z: u32) -> (u16, u16) {
-      if cfg!(target_pointer_width = "64") {
+    if cfg!(target_pointer_width = "64") {
         let z = z as u64;
 
         let z = (z | ((z >> 1) << 32)) & 0x55555555_55555555;
@@ -51,8 +51,8 @@ pub fn deinterleave_morton(z: u32) -> (u16, u16) {
         let x = (z & 0x00000000_0000FFFF) as u16;
         let y = ((z >> 32) & 0x00000000_0000FFFF) as u16;
 
-        (x,y)
-      } else {
+        (x, y)
+    } else {
         let x = z & 0x55555555;
         let x = (x | (x >> 1)) & 0x33333333;
         let x = (x | (x >> 2)) & 0x0F0F0F0F;
@@ -65,233 +65,19 @@ pub fn deinterleave_morton(z: u32) -> (u16, u16) {
         let y = (y | (y >> 4)) & 0x00FF00FF;
         let y = ((y | (y >> 8)) & 0x0000FFFF) as u16;
 
-        (x,y)
-      }
+        (x, y)
+    }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use rand::Rng;
-    use rand::thread_rng;
-
-    use test::Bencher;
-
-    fn idx_tile(x: usize, y: usize, stride: usize) -> usize { stride * y + x }
-    fn idx_tile_tuple(xy: (u16,u16), stride: usize) -> usize { let (x,y) = xy; stride * y as usize + x as usize }
-
-    #[test]
-    fn test_interleave() {
-        let mut tile_morton = [0;32*32]; // 1024 locations
-        let mut tile_normal = [0;32*32]; // 1024 locations
-        // fill tiles with same random numbers
-        for x in 0..32 {
-            for y in 0..32 {
-                let random = thread_rng().gen::<u32>();
-                tile_morton[interleave_morton(x as u16, y as u16) as usize] = random;
-                tile_normal[idx_tile(x, y, 32)] = random;
-            }
-        }
-        // check that the same random numbers are stored there
-        // (morton curve did not override it's own elements)
-        for x in 0..32 {
-            for y in 0..32 {
-                let morton = tile_morton[interleave_morton(x as u16, y as u16) as usize];
-                let normal = tile_normal[idx_tile(x, y, 32)];
-                assert!(morton == normal);
-            }
-        }
-    }
-    #[test]
-    fn test_deinterleave() {
-        let mut tile_morton = [0;32*32]; // 1024 locations
-        let mut tile_normal = [0;32*32]; // 1024 locations
-        // fill tiles with same random numbers
-        for x in 0..32 {
-            for y in 0..32 {
-                let random = thread_rng().gen::<u32>();
-                tile_morton[interleave_morton(x as u16, y as u16) as usize] = random;
-                tile_normal[idx_tile(x, y, 32)] = random;
-            }
-        }
-        // check that the same random numbers are stored there
-        // (morton curve did not override it's own elements)
-        for z in 0..1024 {
-            let morton = tile_morton[z];
-            let normal = tile_normal[idx_tile_tuple(deinterleave_morton(z as u32), 32) as usize];
-            assert!(morton == normal);
-        }
-    }
-    #[test]
-    fn deinterleave_interleave() {
-        for z in 0..65536 {
-            let (x,y) = deinterleave_morton(z);
-            let morton = interleave_morton(x,y);
-            assert!(morton == z);
-        }
-    }
-    #[test]
-    fn interleave_deinterleave() {
-        for x in 0..1024 {
-            for y in 0..1024 {
-                let morton = interleave_morton(x,y);
-                let (d_x,d_y) = deinterleave_morton(morton);
-                assert!(d_x == x && d_y == y);
-            }
-        }
+/// Private test and bench helper functions
+#[doc(hidden)]
+pub mod utils {
+    pub fn idx_tile_tuple(xy: (u16, u16), stride: usize) -> usize {
+        let (x, y) = xy;
+        stride * y as usize + x as usize
     }
 
-    // tests with random input
-    #[test]
-    fn rand_interleave_deinterleave_1000() {
-        for _ in 0..1024 {
-            let x = thread_rng().gen::<u16>();
-            let y = thread_rng().gen::<u16>();
-            let morton = interleave_morton(x,y);
-            let (d_x,d_y) = deinterleave_morton(morton);
-            assert!(d_x == x && d_y == y);
-        }
-    }
-    #[test]
-    fn rand_deinterleave_interleave_1000() {
-        for _ in 0..1024 {
-            let z = thread_rng().gen::<u32>();
-            let (x,y) = deinterleave_morton(z);
-            let morton = interleave_morton(x,y);
-            assert!(morton == z);
-        }
-    }
-
-    // benchmarks
-    #[bench]
-    fn bench_interleave_1000(b: &mut Bencher) {
-        let x = thread_rng().gen::<u16>();
-        let y = thread_rng().gen::<u16>();
-        b.iter(|| for _ in 0..1000 { test::black_box(interleave_morton(x, y)); });
-    }
-    #[bench]
-    fn bench_deinterleave_1000(b: &mut Bencher) {
-        let morton = thread_rng().gen::<u32>();
-        b.iter(|| for _ in 0..1000 { test::black_box(deinterleave_morton(morton)); });
-    }
-    #[bench]
-    fn bench_interleave_deinterleave_1000(b: &mut Bencher) {
-        let x = thread_rng().gen::<u16>();
-        let y = thread_rng().gen::<u16>();
-        b.iter(|| for _ in 0..1000 { test::black_box(deinterleave_morton(interleave_morton(x, y))); });
-    }
-    #[bench]
-    fn bench_deinterleave_interleave_1000(b: &mut Bencher) {
-        let morton = thread_rng().gen::<u32>();
-        b.iter(|| for _ in 0..1000 {
-            let (x,y) = deinterleave_morton(morton);
-            test::black_box(interleave_morton(x,y));
-        });
-    }
-    #[bench]
-    fn bench_horizontal_access_normal(b: &mut Bencher) {
-        let mut tile_normal = vec![0;2048*2048]; // 16MB allocate more then largest cache
-        // fill tiles with some random numbers
-        for y in 0..2048 {
-            for x in 0..2048 {
-                let random = thread_rng().gen::<u32>();
-                tile_normal[idx_tile(x, y, 2048)] = random;
-            }
-        }
-        // bench horizontal access (x direction)
-        b.iter(|| {
-            for y in 0..2048 {
-                for x in 0..2048 {
-                    test::black_box(tile_normal[idx_tile(x, y, 2048)]);
-                }
-            }
-        });
-    }
-    #[bench]
-    fn bench_vertical_access_normal(b: &mut Bencher) {
-        let mut tile_normal = vec![0;2048*2048]; // 16MB allocate more then largest cache
-        // fill tiles with some random numbers
-        for x in 0..2048 {
-            for y in 0..2048 {
-                let random = thread_rng().gen::<u32>();
-                tile_normal[idx_tile(x, y, 2048)] = random;
-            }
-        }
-        // bench vertical access (y direction)
-        b.iter(|| {
-            for x in 0..2048 {
-                for y in 0..2048 {
-                    test::black_box(tile_normal[idx_tile(x, y, 2048) as usize]);
-                }
-            }
-        });
-    }
-    #[bench]
-    fn bench_morton_access_normal(b: &mut Bencher) {
-        let mut tile_morton = vec![0;2048*2048]; // 16MB allocate more then largest cache
-        // fill tiles with some random numbers
-        for z in 0..2048*2048 {
-            let random = thread_rng().gen::<u32>();
-            tile_morton[idx_tile_tuple(deinterleave_morton(z), 2048) as usize] = random;
-        }
-        // bench horizontal access (x direction)
-        b.iter(|| {
-            for z in 0..2048*2048 {
-                test::black_box(tile_morton[idx_tile_tuple(deinterleave_morton(z), 2048) as usize]);
-            }
-        });
-    }
-    #[bench]
-    fn bench_horizontal_access_morton(b: &mut Bencher) {
-        let mut tile_morton = vec![0;2048*2048]; // 16MB allocate more then largest cache
-        // fill tiles with some random numbers
-        for y in 0..2048 {
-            for x in 0..2048 {
-                let random = thread_rng().gen::<u32>();
-                tile_morton[interleave_morton(x, y) as usize] = random;
-            }
-        }
-        // bench horizontal access (x direction)
-        b.iter(|| {
-            for y in 0..2048 {
-                for x in 0..2048 {
-                    test::black_box(tile_morton[interleave_morton(x,y) as usize]);
-                }
-            }
-        });
-    }
-    #[bench]
-    fn bench_vertical_access_morton(b: &mut Bencher) {
-        let mut tile_morton = vec![0;2048*2048]; // 16MB allocate more then largest cache
-        // fill tiles with some random numbers
-        for x in 0..2048 {
-            for y in 0..2048 {
-                let random = thread_rng().gen::<u32>();
-                tile_morton[interleave_morton(x, y) as usize] = random;
-            }
-        }
-        // bench vertical access (y direction)
-        b.iter(|| {
-            for x in 0..2048 {
-                for y in 0..2048 {
-                    test::black_box(tile_morton[interleave_morton(x,y) as usize]);
-                }
-            }
-        });
-    }
-    #[bench]
-    fn bench_morton_access_morton(b: &mut Bencher) {
-        let mut tile_morton = vec![0;2048*2048]; // 16MB allocate more then largest cache
-        // fill tiles with some random numbers
-        for z in 0..2048*2048 {
-            let random = thread_rng().gen::<u32>();
-            tile_morton[z] = random;
-        }
-        // bench horizontal access (x direction)
-        b.iter(|| {
-            for z in 0..2048*2048 {
-                test::black_box(tile_morton[z]);
-            }
-        });
+    pub fn idx_tile(x: usize, y: usize, stride: usize) -> usize {
+        stride * y + x
     }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,0 +1,90 @@
+use rand::{thread_rng, Rng};
+
+use morton::utils::{idx_tile, idx_tile_tuple};
+use morton::{deinterleave_morton, interleave_morton};
+
+#[test]
+fn interleave() {
+    let mut tile_morton = [0; 32 * 32]; // 1024 locations
+    let mut tile_normal = [0; 32 * 32]; // 1024 locations
+                                        // fill tiles with same random numbers
+    for x in 0..32 {
+        for y in 0..32 {
+            let random = thread_rng().gen::<u32>();
+            tile_morton[interleave_morton(x as u16, y as u16) as usize] = random;
+            tile_normal[idx_tile(x, y, 32)] = random;
+        }
+    }
+    // check that the same random numbers are stored there
+    // (morton curve did not override it's own elements)
+    for x in 0..32 {
+        for y in 0..32 {
+            let morton = tile_morton[interleave_morton(x as u16, y as u16) as usize];
+            let normal = tile_normal[idx_tile(x, y, 32)];
+            assert!(morton == normal);
+        }
+    }
+}
+
+#[test]
+fn deinterleave() {
+    let mut tile_morton = [0; 32 * 32]; // 1024 locations
+    let mut tile_normal = [0; 32 * 32]; // 1024 locations
+                                        // fill tiles with same random numbers
+    for x in 0..32 {
+        for y in 0..32 {
+            let random = thread_rng().gen::<u32>();
+            tile_morton[interleave_morton(x as u16, y as u16) as usize] = random;
+            tile_normal[idx_tile(x, y, 32)] = random;
+        }
+    }
+    // check that the same random numbers are stored there
+    // (morton curve did not override it's own elements)
+    for z in 0..1024 {
+        let morton = tile_morton[z];
+        let normal = tile_normal[idx_tile_tuple(deinterleave_morton(z as u32), 32) as usize];
+        assert!(morton == normal);
+    }
+}
+
+#[test]
+fn deinterleave_interleave() {
+    for z in 0..65536 {
+        let (x, y) = deinterleave_morton(z);
+        let morton = interleave_morton(x, y);
+        assert!(morton == z);
+    }
+}
+
+#[test]
+fn interleave_deinterleave() {
+    for x in 0..1024 {
+        for y in 0..1024 {
+            let morton = interleave_morton(x, y);
+            let (d_x, d_y) = deinterleave_morton(morton);
+            assert!(d_x == x && d_y == y);
+        }
+    }
+}
+
+// tests with random input
+#[test]
+fn rand_interleave_deinterleave_1000() {
+    for _ in 0..1024 {
+        let x = thread_rng().gen::<u16>();
+        let y = thread_rng().gen::<u16>();
+        let morton = interleave_morton(x, y);
+        let (d_x, d_y) = deinterleave_morton(morton);
+        assert!(d_x == x && d_y == y);
+    }
+}
+
+#[test]
+fn rand_deinterleave_interleave_1000() {
+    for _ in 0..1024 {
+        let z = thread_rng().gen::<u32>();
+        let (x, y) = deinterleave_morton(z);
+        let morton = interleave_morton(x, y);
+        assert!(morton == z);
+    }
+}


### PR DESCRIPTION
Hey @ReinierMaas - thanks for writing this (a few years ago). Looking to use this in a project, but need it to build on the stable channel, which required some code changes, proposed here.

I'd also be happy to adopt the crate and publish if you want to share maintainership.

## Changes

No functional changes.

As bench is still not stable, use bencher crate. Split testing and benchmarks out to their own modules.

Remove template and default elements from cargo file. Update to 2018 edition of Rust.

Bump version to 0.3.0.

Add a little documentation and fix clippy lints.